### PR TITLE
Express JWT was not using wildcards for /auth subdomains

### DIFF
--- a/backend/handlers/security.js
+++ b/backend/handlers/security.js
@@ -20,8 +20,6 @@ module.exports = {
 		return expressJwt({
 			secret: process.env.TOKEN_SECRET,
 			isRevoked: isRevoked
-		}).unless({
-			path: ["/api/auth"]
-		});
+		}).unless({path: [/^\/api\/auth\/.*/]});
 	}
 };


### PR DESCRIPTION
Added a regexp to allow the user to login/logout/signup without using a JWT.